### PR TITLE
Fix help message to not give the wrong flag caps

### DIFF
--- a/csokoban/csokoban.c
+++ b/csokoban/csokoban.c
@@ -37,7 +37,7 @@ typedef	struct startupdata {
 /* Online help.
  */
 static char const *yowzitch = 
-	"Usage: csokoban [-hvqlwW] [-d DIR] [-s DIR] [NAME] [-LEVEL]\n"
+	"Usage: csokoban [-hvqlwW] [-D DIR] [-S DIR] [NAME] [-LEVEL]\n"
 	"   -h  Display this help\n"
 	"   -v  Display version information\n"
 	"   -l  Print out the list of available setup files\n"


### PR DESCRIPTION
I was confused when it said `-s DIR` and said it was an invalid option.